### PR TITLE
Update SRP rates as of May 2024. Add flag for excluding solar plans

### DIFF
--- a/lib/plans/srp/basic.rb
+++ b/lib/plans/srp/basic.rb
@@ -32,22 +32,22 @@ module Plans
         l = level date
         case season(date)
         when :winter
-          0.0782
+          0.0976
         when :summer
           case l
           when :off_peak
-            0.1091
+            0.1267
           when :on_peak
-            0.1134
+            0.1310
           else
             raise "Bad level"
           end
         when :summer_peak
           case l
           when :off_peak
-            0.1157
+            0.1333
           when :on_peak
-            0.127
+            0.1446
           else
             raise "Bad level"
           end

--- a/lib/plans/srp/ev.rb
+++ b/lib/plans/srp/ev.rb
@@ -25,33 +25,33 @@ module Plans
         when :winter
           case l
           when :super_off_peak
-            0.0575
+            0.0769
           when :off_peak
-            0.0737
+            0.0931
           when :on_peak
-            0.0951
+            0.1145
           else
             raise "Bad level"
           end
         when :summer
           case l
           when :super_off_peak
-            0.0611
+            0.0787
           when :off_peak
-            0.0765
+            0.0941
           when :on_peak
-            0.2094
+            0.2270
           else
             raise "Bad level"
           end
         when :summer_peak
           case l
           when :super_off_peak
-            0.0614
+            0.0790
           when :off_peak
-            0.0770
+            0.0946
           when :on_peak
-            0.2409
+            0.2585
           else
             raise "Bad level"
           end

--- a/lib/plans/srp/ezthree.rb
+++ b/lib/plans/srp/ezthree.rb
@@ -24,27 +24,27 @@ module Plans
         when :winter
           case l
           when :off_peak
-            0.0738
+            0.0932
           when :on_peak
-            0.1063
+            0.1257
           else
             raise "Bad level"
           end
         when :summer
           case l
           when :off_peak
-            0.0829
+            0.1005
           when :on_peak
-            0.2895
+            0.3071
           else
             raise "Bad level"
           end
         when :summer_peak
           case l
           when :off_peak
-            0.0853
+            0.1029
           when :on_peak
-            0.3444
+            0.3620
           else
             raise "Bad level"
           end

--- a/lib/plans/srp/m_power.rb
+++ b/lib/plans/srp/m_power.rb
@@ -10,11 +10,13 @@ module Plans
       def rate(date)
         case season(date)
         when :winter
-          0.0782
+          0.0976
         when :summer
-          0.1114
+          0.1290
+        when :summer_peak
+          0.1361
         else
-          0.1185
+          raise "bad rate"
         end
       end
     end

--- a/lib/plans/srp/time_of_use.rb
+++ b/lib/plans/srp/time_of_use.rb
@@ -17,27 +17,27 @@ module Plans
         when :winter
           case l
           when :off_peak
-            0.0691
+            0.0885
           when :on_peak
-            0.0951
+            0.1145
           else
             raise "Bad level"
           end
         when :summer
           case l
           when :off_peak
-            0.0727
+            0.0903
           when :on_peak
-            0.2094
+            0.2270
           else
             raise "Bad level"
           end
         when :summer_peak
           case l
           when :off_peak
-            0.0730
+            0.0906
           when :on_peak
-            0.2409
+            0.2585
           else
             raise "Bad level"
           end

--- a/power.rb
+++ b/power.rb
@@ -62,6 +62,10 @@ parser = OptionParser.new do |opts|
   opts.on("-s", "--schedule file", "PVWatts Hourly Generation Schedule CSV") do |v|
     options[:pvwatts] = v
   end
+
+  opts.on("--exclude-solar-plans", "Exclude Solar Plans") do |v|
+    options[:exclude_solar_plans] = true
+  end
 end
 
 begin
@@ -105,8 +109,10 @@ if options[:demand_schedule]
   end
 end
 
-plans = root::PLANS.select { |c| !options[:offset] || c.solar_eligible }.map { |c| c.new(logger, demand_schedule, options) }
-plans = root::PLANS.map { |c| c.new(logger, demand_schedule, options) }
+applicable_plans = root::PLANS.reject{|c| c.solar_eligible if options[:exclude_solar_plans]}
+
+plans = applicable_plans.select { |c| !options[:offset] || c.solar_eligible }.map { |c| c.new(logger, demand_schedule, options) }
+plans = applicable_plans.map { |c| c.new(logger, demand_schedule, options) }
 
 CSV.open(options[:csv], headers: true) do |csv|
   arr = csv.to_a


### PR DESCRIPTION
Update SRP rates as of May 2024.
Add --exclude-solar-plans flag (useful if you don't use solar)